### PR TITLE
Fixed socket error code for Windows

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -124,7 +124,7 @@ class Socket implements Closeable
     function throwSocketError()
     {
         $socketErrCode = socket_last_error();
-        if ($socketErrCode === SOCKET_EAGAIN) {
+        if ($socketErrCode === defined('SOCKET_EAGAIN') ? SOCKET_EAGAIN : SOCKET_EWOULDBLOCK) {
             if (!$this->blocking) {
                 throw new SocketTryAgain();
             } else {


### PR DESCRIPTION
On Windows, the reported error is "SOCKET_EWOULDBLOCK" instead of "SOCKET_EAGAIN".